### PR TITLE
Add back LLM Operator client ID

### DIFF
--- a/deployments/dex-server/templates/configmap.yaml
+++ b/deployments/dex-server/templates/configmap.yaml
@@ -46,8 +46,14 @@ data:
     {{- end }}
 
     staticClients:
-    - id: llmariner
+    # TODO(kenji): Remove once all the CLIs are updated.
+    - id: llm-operator
       name: LLM Operator
+      secret: ZXhhbXBsZS1hcHAtc2VjcmV0
+      redirectURIs:
+      - http://127.0.0.1:5555/callback
+    - id: llmariner
+      name: LLMariner
       secret: ZXhhbXBsZS1hcHAtc2VjcmV0
       redirectURIs:
       - http://127.0.0.1:5555/callback


### PR DESCRIPTION
We cannot remove until all the clients are updated.