### PR TITLE
feat(dex): be able to configure additional static clients

### DIFF
--- a/deployments/dex-server/templates/configmap.yaml
+++ b/deployments/dex-server/templates/configmap.yaml
@@ -62,6 +62,9 @@ data:
       secret: o15FQlUB8SeOOBiw3Pg5vD5p
       redirectURIs:
       - {{ .Values.global.ingress.controllerUrl }}/v1/sessions/callback
+    {{- with .Values.additionalStaticClients }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 
     enablePasswordDB: {{ .Values.enablePasswordDb }}
 

--- a/deployments/dex-server/values.yaml
+++ b/deployments/dex-server/values.yaml
@@ -28,6 +28,8 @@ database:
 
 connectors:
 
+additionalStaticClients:
+
 oauth2:
   passwordConnector:
     enable: true


### PR DESCRIPTION
This is needed when the frontend uses a separate client that uses a different redirect URL.