### PR TITLE
feat(pkg/auth): add ValidateClusterRegistrationKey

### DIFF
--- a/pkg/auth/worker_client.go
+++ b/pkg/auth/worker_client.go
@@ -5,24 +5,37 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strings"
 
 	"google.golang.org/grpc/metadata"
 )
 
 const (
-	envVarname = "LLMO_CLUSTER_REGISTRATION_KEY"
+	envVarName = "LLMO_CLUSTER_REGISTRATION_KEY"
 )
 
 // AppendWorkerAuthorization appends the authorization to the context for a request
 // from a worker cluster.
 func AppendWorkerAuthorization(ctx context.Context) context.Context {
-	key := os.Getenv(envVarname)
+	key := os.Getenv(envVarName)
 	auth := fmt.Sprintf("Bearer %s", key)
 	return metadata.AppendToOutgoingContext(ctx, "Authorization", auth)
 }
 
 // AppendWorkerAuthorizationToHeader appends the authorization to the HTTP header.
 func AppendWorkerAuthorizationToHeader(req *http.Request) {
-	key := os.Getenv(envVarname)
+	key := os.Getenv(envVarName)
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", key))
+}
+
+// ValidateClusterRegistrationKey validates the cluster registration key.
+func ValidateClusterRegistrationKey() error {
+	key := os.Getenv(envVarName)
+	if key == "" {
+		return fmt.Errorf("environment variable %s is not set", envVarName)
+	}
+	if !strings.HasPrefix(key, "clusterkey-") {
+		return fmt.Errorf("invalid cluster registration key")
+	}
+	return nil
 }

--- a/pkg/auth/worker_client_test.go
+++ b/pkg/auth/worker_client_test.go
@@ -1,0 +1,40 @@
+package auth
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateClusterRegistrationKey(t *testing.T) {
+	tcs := []struct {
+		key     string
+		isError bool
+	}{
+		{
+			key:     "clusterkey-1234567890",
+			isError: false,
+		},
+		{
+			key:     "bogus",
+			isError: true,
+		},
+		{
+			key:     "",
+			isError: true,
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.key, func(t *testing.T) {
+			err := os.Setenv(envVarName, tc.key)
+			assert.NoError(t, err)
+			err = ValidateClusterRegistrationKey()
+			if tc.isError {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+		})
+	}
+}


### PR DESCRIPTION
It is often difficult to debug when a bogus cluster registation key is set. This function is helpful to catch such errors more clearly.